### PR TITLE
111

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -15,13 +15,14 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
       - uses: dtolnay/rust-toolchain@nightly
         with:
           toolchain: nightly
           components: rustfmt
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          components: clippy
       - run: cargo test
       - run: target/debug/fibonacci 7 10
       - run: cargo +nightly fmt --check

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -18,7 +18,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          toolchain: nightly
+          components: rustfmt
       - run: cargo test
       - run: target/debug/fibonacci 7 10
-      - run: cargo fmt --check
+      - run: cargo +nightly fmt --check
       - run: cargo clippy

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 target/
 *.profraw
 tarpaulin-report.html
+lcov.info

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@
 node_modules/
 target/
 *.profraw
-tarpaulin-report.html
+tarpaulin-report.html 
 lcov.info

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,11 @@
+trailing_comma = "Never"
+brace_style = "SameLineWhere"
+struct_field_align_threshold = 20
+wrap_comments = true
+format_code_in_doc_comments = true
+struct_lit_single_line = false
+max_width = 99
+imports_granularity = "Crate"
+group_imports = "StdExternalCrate"
+reorder_imports = true
+unstable_features = true

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
 trailing_comma = "Never"
 brace_style = "SameLineWhere"
 struct_field_align_threshold = 20

--- a/README.md
+++ b/README.md
@@ -88,4 +88,4 @@ Then, fork repository, make changes, send us a [pull request](https://www.yegor2
 We will review your changes and apply them to the `master` branch shortly,
 provided they don't violate our quality standards. To avoid frustration,
 before sending us your pull request please run `cargo test` again. Also,
-run `cargo fmt` and `cargo clippy`.
+run `cargo +nightly fmt` and `cargo clippy`.

--- a/src/atom.rs
+++ b/src/atom.rs
@@ -1,10 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2022 Yegor Bugayenko
 // SPDX-License-Identifier: MIT
 
-use crate::basket::Bk;
-use crate::data::Data;
-use crate::emu::Emu;
-use crate::loc::Loc;
+use crate::{basket::Bk, data::Data, emu::Emu, loc::Loc};
 
 pub type Atom = fn(&mut Emu, Bk) -> Option<Data>;
 
@@ -39,7 +36,6 @@ pub fn bool_if(emu: &mut Emu, bk: Bk) -> Option<Data> {
 
 #[cfg(test)]
 use crate::assert_dataized_eq;
-
 #[cfg(test)]
 use crate::emu::Opt;
 

--- a/src/basket.rs
+++ b/src/basket.rs
@@ -1,15 +1,13 @@
 // SPDX-FileCopyrightText: Copyright (c) 2022 Yegor Bugayenko
 // SPDX-License-Identifier: MIT
 
-use crate::data::Data;
-use crate::loc::Loc;
-use crate::object::Ob;
+use std::{collections::HashMap, fmt, str::FromStr};
+
 use itertools::Itertools;
 use regex::Regex;
 use rstest::rstest;
-use std::collections::HashMap;
-use std::fmt;
-use std::str::FromStr;
+
+use crate::{data::Data, loc::Loc, object::Ob};
 
 pub type Bk = isize;
 
@@ -18,21 +16,21 @@ pub enum Kid {
     Rqtd,
     Need(Ob, Bk),
     Wait(Bk, Loc),
-    Dtzd(Data),
+    Dtzd(Data)
 }
 
 pub struct Basket {
-    pub ob: Ob,
-    pub psi: Bk,
-    pub kids: HashMap<Loc, Kid>,
+    pub ob:   Ob,
+    pub psi:  Bk,
+    pub kids: HashMap<Loc, Kid>
 }
 
 impl Basket {
     pub fn empty() -> Basket {
         Basket {
-            ob: 0,
-            psi: -1,
-            kids: HashMap::new(),
+            ob:   0,
+            psi:  -1,
+            kids: HashMap::new()
         }
     }
 
@@ -40,7 +38,7 @@ impl Basket {
         Basket {
             ob,
             psi,
-            kids: HashMap::new(),
+            kids: HashMap::new()
         }
     }
 
@@ -63,7 +61,7 @@ impl fmt::Display for Basket {
                 .iter()
                 .map(|(i, d)| format!("{}{}", i, d))
                 .sorted()
-                .collect::<Vec<String>>(),
+                .collect::<Vec<String>>()
         );
         write!(f, "[{}]", parts.iter().join(", "))
     }
@@ -76,7 +74,7 @@ impl fmt::Display for Kid {
             Kid::Rqtd => "→?".to_string(),
             Kid::Need(ob, bk) => format!("→(ν{};β{})", ob, bk),
             Kid::Wait(bk, loc) => format!("⇉β{}.{}", bk, loc),
-            Kid::Dtzd(d) => format!("⇶0x{:04X}", d),
+            Kid::Dtzd(d) => format!("⇶0x{:04X}", d)
         })
     }
 }
@@ -169,7 +167,7 @@ impl FromStr for Basket {
                     Kid::Need(o_num, psi_num)
                 }
                 "→?" => Kid::Rqtd,
-                _ => return Err(format!("Unknown kid type: '{}'", kind_str)),
+                _ => return Err(format!("Unknown kid type: '{}'", kind_str))
             };
             let loc_str = caps
                 .get(1)
@@ -328,6 +326,6 @@ fn parses_wait_kid() {
             assert_eq!(*bk, 1);
             assert_eq!(*loc, Loc::Delta);
         }
-        _ => panic!("Expected Wait kid"),
+        _ => panic!("Expected Wait kid")
     }
 }

--- a/src/bin/custom_executor.rs
+++ b/src/bin/custom_executor.rs
@@ -4,11 +4,12 @@
 
 extern crate phie;
 
-use phie::data::Data;
-use phie::emu::{Emu, Opt};
-use std::env;
-use std::fs;
-use std::str::FromStr;
+use std::{env, fs, str::FromStr};
+
+use phie::{
+    data::Data,
+    emu::{Emu, Opt}
+};
 
 fn emulate(phi_code: &str) -> Result<Data, String> {
     let mut emu: Emu =

--- a/src/bin/fibonacci.rs
+++ b/src/bin/fibonacci.rs
@@ -3,9 +3,12 @@
 
 extern crate phie;
 
-use phie::data::Data;
-use phie::emu::{Emu, Opt};
 use std::env;
+
+use phie::{
+    data::Data,
+    emu::{Emu, Opt}
+};
 
 pub fn fibo(x: Data) -> Result<Data, String> {
     let mut emu: Emu = format!(

--- a/src/bin/phie.rs
+++ b/src/bin/phie.rs
@@ -21,7 +21,6 @@ extern crate phie;
 use std::{env::args, process::exit};
 
 use env_logger::init as logger_init;
-
 use phie::cli::run;
 
 fn main() {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,14 +14,16 @@
 //! let args = vec!["phie".to_string(), "program.phie".to_string()];
 //! match cli::run(&args) {
 //!     Ok(output) => println!("{}", output),
-//!     Err(e) => eprintln!("Error: {}", e),
+//!     Err(e) => eprintln!("Error: {}", e)
 //! }
 //! ```
 
 use std::{fs, path::Path};
 
-use crate::data::Data;
-use crate::emu::{Emu, Opt};
+use crate::{
+    data::Data,
+    emu::{Emu, Opt}
+};
 
 /// Parses command line arguments and extracts the file path.
 ///
@@ -29,7 +31,8 @@ use crate::emu::{Emu, Opt};
 ///
 /// # Arguments
 ///
-/// * `args` - Slice of command line arguments where first element is program name
+/// * `args` - Slice of command line arguments where first element is program
+///   name
 ///
 /// # Returns
 ///
@@ -57,7 +60,8 @@ pub fn parse_args(args: &[String]) -> Result<String, String> {
 
 /// Reads and returns content from a phie program file.
 ///
-/// Validates file existence before reading and provides detailed error messages.
+/// Validates file existence before reading and provides detailed error
+/// messages.
 ///
 /// # Arguments
 ///
@@ -79,13 +83,14 @@ pub fn read_phie_file(file_path: &str) -> Result<String, String> {
     if !Path::new(file_path).exists() {
         return Err(format!("File '{}' does not exist", file_path));
     }
-    fs::read_to_string(file_path).map_err(|e| format!("Failed to read file '{}': {}", file_path, e))
+    fs::read_to_string(file_path)
+        .map_err(|e| format!("Failed to read file '{}': {}", file_path, e))
 }
 
 /// Executes a phie program and returns the dataized result.
 ///
-/// Parses the program content into an Emu instance, configures execution options,
-/// and performs dataization to compute the result.
+/// Parses the program content into an Emu instance, configures execution
+/// options, and performs dataization to compute the result.
 ///
 /// # Arguments
 ///
@@ -135,7 +140,7 @@ pub fn execute_phie(content: &str) -> Result<Data, String> {
 /// let args = vec!["phie".to_string(), "program.phie".to_string()];
 /// match run(&args) {
 ///     Ok(output) => println!("{}", output),
-///     Err(e) => eprintln!("Error: {}", e),
+///     Err(e) => eprintln!("Error: {}", e)
 /// }
 /// ```
 pub fn run(args: &[String]) -> Result<String, String> {

--- a/src/emu.rs
+++ b/src/emu.rs
@@ -6,16 +6,18 @@ mod tests;
 mod tests_transitions;
 mod transitions;
 
-use crate::basket::{Basket, Bk, Kid};
-use crate::data::Data;
-use crate::loc::Loc;
-use crate::object::{Ob, Object};
+use std::{collections::HashSet, fmt, str::FromStr};
+
 use arr_macro::arr;
 use log::trace;
 use regex::Regex;
-use std::collections::HashSet;
-use std::fmt;
-use std::str::FromStr;
+
+use crate::{
+    basket::{Basket, Bk, Kid},
+    data::Data,
+    loc::Loc,
+    object::{Ob, Object}
+};
 
 pub const ROOT_BK: Bk = 0;
 pub const ROOT_OB: Ob = 0;
@@ -28,13 +30,13 @@ pub enum Opt {
     DontDelete,
     LogSnapshots,
     StopWhenTooManyCycles,
-    StopWhenStuck,
+    StopWhenStuck
 }
 
 pub struct Emu {
     pub objects: [Object; MAX_OBJECTS],
     pub baskets: [Basket; MAX_BASKETS],
-    pub opts: HashSet<Opt>,
+    pub opts:    HashSet<Opt>
 }
 
 impl fmt::Display for Emu {
@@ -113,7 +115,7 @@ impl Emu {
         let mut emu = Emu {
             objects: arr![Object::open(); 16],
             baskets: arr![Basket::empty(); 128],
-            opts: HashSet::new(),
+            opts:    HashSet::new()
         };
         let mut basket = Basket::start(0, 0);
         basket.kids.insert(Loc::Phi, Kid::Rqtd);
@@ -159,7 +161,7 @@ impl Emu {
                 None
             }
             Some(Kid::Need(_, _)) | Some(Kid::Wait(_, _)) | Some(Kid::Rqtd) => None,
-            Some(Kid::Dtzd(d)) => Some(*d),
+            Some(Kid::Dtzd(d)) => Some(*d)
         }
     }
 }

--- a/src/emu/dataization.rs
+++ b/src/emu/dataization.rs
@@ -1,13 +1,17 @@
 // SPDX-FileCopyrightText: Copyright (c) 2022 Yegor Bugayenko
 // SPDX-License-Identifier: MIT
 
-use crate::basket::{Bk, Kid};
-use crate::data::Data;
-use crate::emu::{Emu, Opt, ROOT_BK};
-use crate::loc::Loc;
-use crate::perf::Perf;
-use log::debug;
 use std::time::Instant;
+
+use log::debug;
+
+use crate::{
+    basket::{Bk, Kid},
+    data::Data,
+    emu::{Emu, Opt, ROOT_BK},
+    loc::Loc,
+    perf::Perf
+};
 
 const MAX_CYCLES: usize = 65536;
 

--- a/src/emu/tests.rs
+++ b/src/emu/tests.rs
@@ -2,31 +2,24 @@
 // SPDX-License-Identifier: MIT
 
 #[cfg(test)]
-use crate::emu::{Emu, Opt};
-
-#[cfg(test)]
-use crate::perf::Transition;
-
-#[cfg(test)]
-use crate::loc::Loc;
-
-#[cfg(test)]
-use crate::locator::Locator;
-
-#[cfg(test)]
-use crate::data::Data;
-
-#[cfg(test)]
-use crate::ph;
+use std::str::FromStr;
 
 #[cfg(test)]
 use crate::assert_dataized_eq;
-
+#[cfg(test)]
+use crate::data::Data;
+#[cfg(test)]
+use crate::emu::{Emu, Opt};
+#[cfg(test)]
+use crate::loc::Loc;
+#[cfg(test)]
+use crate::locator::Locator;
 #[cfg(test)]
 use crate::object::Object;
-
 #[cfg(test)]
-use std::str::FromStr;
+use crate::perf::Transition;
+#[cfg(test)]
+use crate::ph;
 
 #[test]
 pub fn simple_dataization_cycle() {
@@ -95,7 +88,7 @@ pub fn preserves_calculation_results() {
         ν3(𝜋) ↦ ⟦ λ ↦ int-add, ρ ↦ ν4(𝜋), 𝛼0 ↦ ν9(𝜋) ⟧
         ν4(𝜋) ↦ ⟦ λ ↦ int-neg, ρ ↦ ν9(𝜋) ⟧
         ν9(𝜋) ↦ ⟦ Δ ↦ 0x002A ⟧
-        ",
+        "
     )
     .unwrap();
     let (result, perf) = emu.dataize();
@@ -122,7 +115,7 @@ pub fn calculates_argument_once() {
         ν3(𝜋) ↦ ⟦ λ ↦ int-add, ρ ↦ ν4(𝜋), 𝛼0 ↦ ν9(𝜋) ⟧
         ν4(𝜋) ↦ ⟦ λ ↦ int-neg, ρ ↦ ν9(𝜋) ⟧
         ν9(𝜋) ↦ ⟦ Δ ↦ 0x002A ⟧
-        ",
+        "
     )
     .unwrap();
     let (result, perf) = emu.dataize();
@@ -398,7 +391,7 @@ pub fn simple_recursion() {
         ν8(𝜋) ↦ ⟦ Δ ↦ 0x0001 ⟧
         ν9(𝜋) ↦ ⟦ 𝜑 ↦ ν1(ξ), 𝛼0 ↦ ν10(𝜋) ⟧
         ν10(𝜋) ↦ ⟦ Δ ↦ 0x0007 ⟧
-        ",
+        "
     )
     .unwrap();
     emu.opt(Opt::DontDelete);
@@ -445,7 +438,7 @@ pub fn recursive_fibonacci() {
             ",
             input
         )
-        .as_str(),
+        .as_str()
     )
     .unwrap();
     let (result, perf) = emu.dataize();

--- a/src/emu/tests_transitions.rs
+++ b/src/emu/tests_transitions.rs
@@ -2,14 +2,12 @@
 // SPDX-License-Identifier: MIT
 
 #[cfg(test)]
-use crate::basket::Basket;
-
-#[cfg(test)]
 use std::str::FromStr;
 
 #[cfg(test)]
+use crate::basket::Basket;
+#[cfg(test)]
 use crate::emu::Emu;
-
 #[cfg(test)]
 use crate::perf::Perf;
 

--- a/src/emu/transitions.rs
+++ b/src/emu/transitions.rs
@@ -1,14 +1,17 @@
 // SPDX-FileCopyrightText: Copyright (c) 2022 Yegor Bugayenko
 // SPDX-License-Identifier: MIT
 
-use crate::basket::{Basket, Bk, Kid};
-use crate::emu::{Emu, MAX_BASKETS, ROOT_BK, ROOT_OB};
-use crate::loc::Loc;
-use crate::locator::Locator;
-use crate::object::{Ob, Object};
-use crate::perf::{Perf, Transition};
 use itertools::Itertools;
 use log::trace;
+
+use crate::{
+    basket::{Basket, Bk, Kid},
+    emu::{Emu, MAX_BASKETS, ROOT_BK, ROOT_OB},
+    loc::Loc,
+    locator::Locator,
+    object::{Ob, Object},
+    perf::{Perf, Transition}
+};
 
 macro_rules! join {
     ($log:expr) => {
@@ -236,7 +239,7 @@ impl Emu {
                         log.push(format!("+{}", p));
                         ob
                     }
-                },
+                }
             };
             ob = next;
             ret = Ok((next, psi, attr.clone()))

--- a/src/loc.rs
+++ b/src/loc.rs
@@ -1,11 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2022 Yegor Bugayenko
 // SPDX-License-Identifier: MIT
 
-use crate::object::Ob;
+use std::{fmt, str::FromStr};
+
 use regex::Regex;
 use rstest::rstest;
-use std::fmt;
-use std::str::FromStr;
+
+use crate::object::Ob;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Loc {
@@ -16,14 +17,14 @@ pub enum Loc {
     Delta,
     Sigma,
     Attr(i8),
-    Obj(Ob),
+    Obj(Ob)
 }
 
 impl FromStr for Loc {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let re_arg =
-            Regex::new("^𝛼?(\\d+)$").map_err(|e| format!("Invalid RE_ARG regex pattern: {}", e))?;
+        let re_arg = Regex::new("^𝛼?(\\d+)$")
+            .map_err(|e| format!("Invalid RE_ARG regex pattern: {}", e))?;
         let re_obj =
             Regex::new("^ν(\\d+)$").map_err(|e| format!("Invalid RE_OBJ regex pattern: {}", e))?;
 
@@ -53,7 +54,7 @@ impl FromStr for Loc {
                 "ρ" | "^" => Ok(Loc::Rho),
                 "𝜑" | "@" => Ok(Loc::Phi),
                 "σ" | "&" => Ok(Loc::Sigma),
-                _ => Err(format!("Unknown loc: '{}'", s)),
+                _ => Err(format!("Unknown loc: '{}'", s))
             }
         }
     }
@@ -69,7 +70,7 @@ impl fmt::Display for Loc {
             Loc::Pi => "𝜋".to_owned(),
             Loc::Sigma => "σ".to_owned(),
             Loc::Attr(i) => format!("𝛼{}", i),
-            Loc::Obj(i) => format!("ν{}", i),
+            Loc::Obj(i) => format!("ν{}", i)
         })
     }
 }

--- a/src/locator.rs
+++ b/src/locator.rs
@@ -1,25 +1,25 @@
 // SPDX-FileCopyrightText: Copyright (c) 2022 Yegor Bugayenko
 // SPDX-License-Identifier: MIT
 
-use crate::loc::Loc;
+use std::{fmt, str::FromStr};
+
 use rstest::rstest;
-use std::fmt;
-use std::str::FromStr;
+
+use crate::loc::Loc;
 
 /// Locator is a chain of attributes connected with dots,
 /// for example `𝜋.𝜋.𝛼0` is a locator.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Locator {
-    locs: Vec<Loc>,
+    locs: Vec<Loc>
 }
 
 /// Use this macro to create a locator faster:
 ///
 /// ```
-/// use phie::ph;
-/// use phie::loc::Loc;
-/// use phie::locator::Locator;
 /// use std::str::FromStr;
+///
+/// use phie::{loc::Loc, locator::Locator, ph};
 /// let k = ph!("𝜋.𝜋.𝛼0");
 /// ```
 #[macro_export]
@@ -33,19 +33,19 @@ impl Locator {
     /// Make a locator from a vector of attribute names:
     ///
     /// ```
-    /// use phie::loc::Loc;
-    /// use phie::locator::Locator;
+    /// use phie::{loc::Loc, locator::Locator};
     /// let k = Locator::from_vec(vec![Loc::Phi, Loc::Delta]);
     /// ```
     pub fn from_vec(locs: Vec<Loc>) -> Locator {
-        Locator { locs }
+        Locator {
+            locs
+        }
     }
 
     /// Make a locator from a single attribute:
     ///
     /// ```
-    /// use phie::loc::Loc;
-    /// use phie::locator::Locator;
+    /// use phie::{loc::Loc, locator::Locator};
     /// let k = Locator::from_loc(Loc::Phi);
     /// ```
     pub fn from_loc(loc: Loc) -> Locator {
@@ -69,7 +69,9 @@ impl FromStr for Locator {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let locs_result: Result<Vec<Loc>, String> = s.split('.').map(Loc::from_str).collect();
-        let p = Locator { locs: locs_result? };
+        let p = Locator {
+            locs: locs_result?
+        };
 
         let checks: [CheckFn; 4] = [
             |p: &Locator| -> Option<String> {
@@ -99,7 +101,7 @@ impl FromStr for Locator {
                 } else {
                     None
                 }
-            },
+            }
         ];
 
         for check in checks.iter() {
@@ -119,7 +121,7 @@ impl fmt::Display for Locator {
                 .iter()
                 .map(|i| i.to_string())
                 .collect::<Vec<String>>()
-                .join("."),
+                .join(".")
         )
     }
 }
@@ -172,7 +174,7 @@ pub fn fails_on_incorrect_locator(#[case] locator: String) {
 pub fn fetches_loc_from_locator(
     #[case] locator: String,
     #[case] idx: usize,
-    #[case] expected: Loc,
+    #[case] expected: Loc
 ) {
     assert_eq!(*ph!(&locator).loc(idx).unwrap(), expected);
 }

--- a/src/object.rs
+++ b/src/object.rs
@@ -1,51 +1,48 @@
 // SPDX-FileCopyrightText: Copyright (c) 2022 Yegor Bugayenko
 // SPDX-License-Identifier: MIT
 
-use crate::atom::*;
-use crate::data::Data;
-use crate::loc::Loc;
-use crate::locator::Locator;
+use std::{collections::HashMap, fmt, str::FromStr};
+
 use itertools::Itertools;
 use regex::Regex;
 use rstest::rstest;
-use std::collections::HashMap;
-use std::fmt;
-use std::str::FromStr;
+
+use crate::{atom::*, data::Data, loc::Loc, locator::Locator};
 
 pub type Ob = usize;
 
 pub struct Object {
-    pub delta: Option<Data>,
-    pub lambda: Option<(String, Atom)>,
+    pub delta:    Option<Data>,
+    pub lambda:   Option<(String, Atom)>,
     pub constant: bool,
-    pub attrs: HashMap<Loc, (Locator, bool)>,
+    pub attrs:    HashMap<Loc, (Locator, bool)>
 }
 
 impl Object {
     pub fn open() -> Object {
         Object {
-            delta: None,
-            lambda: None,
+            delta:    None,
+            lambda:   None,
             constant: false,
-            attrs: HashMap::new(),
+            attrs:    HashMap::new()
         }
     }
 
     pub fn dataic(d: Data) -> Object {
         Object {
-            delta: Some(d),
-            lambda: None,
+            delta:    Some(d),
+            lambda:   None,
             constant: true,
-            attrs: HashMap::new(),
+            attrs:    HashMap::new()
         }
     }
 
     pub fn atomic(n: String, a: Atom) -> Object {
         Object {
-            delta: None,
-            lambda: Some((n, a)),
+            delta:    None,
+            lambda:   Some((n, a)),
             constant: false,
-            attrs: HashMap::new(),
+            attrs:    HashMap::new()
         }
     }
 
@@ -63,16 +60,13 @@ impl Object {
     /// first child.
     ///
     /// ```
-    /// use phie::loc::Loc;
-    /// use phie::locator::Locator;
-    /// use phie::object::Object;
     /// use std::str::FromStr;
-    /// use phie::ph;
+    ///
+    /// use phie::{loc::Loc, locator::Locator, object::Object, ph};
     /// let mut obj = Object::open();
     /// obj.push(Loc::Phi, ph!("ν13"), false);
     /// obj.push(Loc::Attr(0), ph!("ρ.1"), false);
     /// ```
-    ///
     pub fn push(&mut self, loc: Loc, p: Locator, xi: bool) -> &mut Object {
         self.attrs.insert(loc, (p, xi));
         self
@@ -81,14 +75,13 @@ impl Object {
     /// You can do the same, but with "fluent interface" of the `Object`.
     ///
     /// ```
-    /// use phie::loc::Loc;
-    /// use phie::locator::Locator;
-    /// use phie::object::Object;
     /// use std::str::FromStr;
-    /// use phie::ph;
-    /// let obj = Object::open()
-    ///   .with(Loc::Phi, ph!("ν13"), false)
-    ///   .with(Loc::Attr(0), ph!("ρ.1"), false);
+    ///
+    /// use phie::{loc::Loc, locator::Locator, object::Object, ph};
+    /// let obj =
+    ///     Object::open()
+    ///         .with(Loc::Phi, ph!("ν13"), false)
+    ///         .with(Loc::Attr(0), ph!("ρ.1"), false);
     /// ```
     pub fn with(&self, loc: Loc, p: Locator, xi: bool) -> Object {
         let mut obj = self.copy();
@@ -145,8 +138,8 @@ impl fmt::Display for Object {
 impl FromStr for Object {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let re =
-            Regex::new("⟦(!?)(.*)⟧").map_err(|e| format!("Invalid object regex pattern: {}", e))?;
+        let re = Regex::new("⟦(!?)(.*)⟧")
+            .map_err(|e| format!("Invalid object regex pattern: {}", e))?;
         let mut obj = Object::open();
         let caps = re
             .captures(s)
@@ -176,7 +169,7 @@ impl FromStr for Object {
                         "int-neg" => int_neg,
                         "bool-if" => bool_if,
                         "int-less" => int_less,
-                        _ => return Err(format!("Unknown lambda '{}' in '{}'", p, s)),
+                        _ => return Err(format!("Unknown lambda '{}' in '{}'", p, s))
                     };
                     obj = Object::atomic(p.to_string(), lambda_fn);
                 }

--- a/src/perf.rs
+++ b/src/perf.rs
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2022 Yegor Bugayenko
 // SPDX-License-Identifier: MIT
 
+use std::{collections::HashMap, fmt};
+
 use itertools::Itertools;
-use std::collections::HashMap;
-use std::fmt;
 
 #[derive(Hash, Eq, PartialEq, strum_macros::Display)]
 pub enum Transition {
@@ -12,15 +12,15 @@ pub enum Transition {
     NEW,
     DLG,
     PPG,
-    FIND,
+    FIND
 }
 
 pub struct Perf {
     pub cycles: usize,
-    pub peak: usize,
-    pub atoms: HashMap<String, usize>,
-    pub hits: HashMap<Transition, usize>,
-    pub ticks: HashMap<Transition, usize>,
+    pub peak:   usize,
+    pub atoms:  HashMap<String, usize>,
+    pub hits:   HashMap<Transition, usize>,
+    pub ticks:  HashMap<Transition, usize>
 }
 
 impl Default for Perf {
@@ -32,11 +32,11 @@ impl Default for Perf {
 impl Perf {
     pub fn new() -> Perf {
         Perf {
-            atoms: HashMap::new(),
-            ticks: HashMap::new(),
-            hits: HashMap::new(),
+            atoms:  HashMap::new(),
+            ticks:  HashMap::new(),
+            hits:   HashMap::new(),
             cycles: 0,
-            peak: 0,
+            peak:   0
         }
     }
 
@@ -78,7 +78,7 @@ macro_rules! print {
             $list
                 .iter()
                 .map(|(t, c)| format!("\t{}: {}", t, c))
-                .sorted(),
+                .sorted()
         );
         $lines.push(format!("\tTotal: {}", $total));
     };

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2022 Yegor Bugayenko
 // SPDX-License-Identifier: MIT
 
+use std::{fs, path::PathBuf};
+
 use phie::cli;
-use std::fs;
-use std::path::PathBuf;
 
 fn mktemp(filename: &str) -> (PathBuf, String) {
     let mut file = std::env::temp_dir();


### PR DESCRIPTION
## Changes

This PR implements consistent formatting across the codebase by switching to nightly rustfmt with RustManifest-based configuration.

**What's included:**
- Added `.rustfmt.toml` configuration file based on [RustManifest formatting standards](https://github.com/RAprogramm/RustManifest#1-formatting-standards)
- Updated CI workflow to use `cargo +nightly fmt --check`
- Applied nightly rustfmt to entire codebase

**Benefits:**
- Eliminates formatting inconsistencies between local development and CI
- Provides more precise formatting control through unstable features
- Follows professional Rust project standards

Closes #111