### PR TITLE
#108: migrate coverage from tarpaulin to cargo-llvm-cov

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
-name: tarpaulin
+name: coverage
 'on':
   push:
   pull_request:
@@ -10,19 +10,19 @@ jobs:
   check:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v5
-      - name: Install OpenSSL 1.1
-        run: |
-          wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_amd64.deb
-          sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2_amd64.deb
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
-      - uses: actions-rs/tarpaulin@v0.1
-        with:
-          version: '0.22.0'
-          args: '--all-features --exclude-files src/lib.rs -- --test-threads 1'
+          components: llvm-tools-preview
+      - uses: taiki-e/install-action@cargo-llvm-cov
+      - run: cargo llvm-cov --all-features --ignore-filename-regex 'src/lib\.rs$' --lcov --output-path lcov.info -- --test-threads 1
       - uses: codecov/codecov-action@v5
         with:
+          files: lcov.info
           fail_ci_if_error: true
+          use_oidc: true

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 node_modules/
 target/
 *.profraw
-tarpaulin-report.html
+lcov.info

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,3 @@ rstest = "0.26"
 assert_cmd = "2.0"
 simple_logger = "5.1"
 predicates = "3.0"
-
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin)'] }


### PR DESCRIPTION
Closes #108

This is the coverage part of #103, extracted so it can be reviewed on its own,
without waiting for the Rust atoms work. It implements the tool agreed upon in
that discussion: @hanMaster proposed `cargo-llvm-cov` on 2025-11-10. Once this is
merged, #103 will be rebased to drop these files and to close #33 alone.

## What changed

`tarpaulin.yml` becomes `coverage.yml`, renamed so the history is kept:

| Before | After |
|---|---|
| `actions-rs/tarpaulin@v0.1`, unmaintained, Node 20 | `taiki-e/install-action@cargo-llvm-cov` |
| `cargo-tarpaulin` pinned to `0.22.0`, released 2022 | `cargo-llvm-cov`, latest at run time |
| `libssl1.1` `.deb` from the Ubuntu Bionic archive, installed with `dpkg` on `ubuntu-24.04` | nothing to install, the `llvm-tools-preview` component only |
| `--exclude-files src/lib.rs` | `--ignore-filename-regex 'src/lib\.rs$'` |
| implicit report discovery | explicit `files: lcov.info` |
| upload authenticated by a token that does not exist | upload authenticated by GitHub OIDC |

Two leftovers of the old tool go with it: the dead
`[lints.rust] unexpected_cfgs = { check-cfg = ['cfg(tarpaulin)'] }` in
`Cargo.toml`, since no `cfg(tarpaulin)` exists anywhere in `src`, and
`tarpaulin-report.html` in `.gitignore`, replaced by `lcov.info`. Production code
is untouched and the edition stays at 2021.

## Why the upload was failing, and why it stops

`cargo-tarpaulin` was never the reason `master` was red. Coverage was collected
fine; the upload died on
`{"message":"Token required because branch is protected"}`, which needs a
`CODECOV_TOKEN` secret. Rather than ask you to add one, the job now authenticates
with GitHub OIDC, which needs no secret at all: `id-token: write` plus
`use_oidc: true`.

Pull requests from forks keep working exactly as before. I read the action to be
sure rather than assume: `codecov/codecov-action@v5` computes `CC_FORK` from the
pull request head repository, and its OIDC step is skipped whenever `CC_FORK` is
`true`, so a fork pull request still takes the tokenless route that worked for
#103 in November. This pull request is itself the proof: it comes from a fork,
and Codecov reported its patch and project statuses here. OIDC applies to pushes
into this repository, which is precisely where the protected-branch error was
raised.

The job also declares least-privilege permissions, `contents: read` and
`id-token: write`, which OIDC requires anyway.

## Verification

Every check of this repository was reproduced locally on this branch — `cargo
test` with 240 tests including doc-tests, `target/debug/fibonacci 7 10`, `cargo
fmt --check`, `cargo clippy`, `actionlint`, `yamllint --strict`, `reuse lint` at
42 of 42 files, `typos` on the changed files, `markdownlint-cli2` — and the
workflow itself was run end to end in my fork.

That run is also where the OIDC claim above comes from. Without OIDC the upload
answered `Token required - not valid tokenless upload`. With OIDC it obtained a
1936-character identity token, the CLI ran with it, and the answer changed to
`Repository not found` — my fork is simply not a project on Codecov, while this
repository is. Authentication is therefore no longer the obstacle, which is the
only thing that error message could have been telling us.

The exclusion regex was checked rather than assumed: `cargo-llvm-cov` matches the
pattern against absolute paths, so an anchored `^src/lib\.rs$` would silently
match nothing. Substituting `src/perf\.rs$` dropped `perf.rs` from the report,
14 files down to 13, confirming the suffix form is the one that works.
