### PR TITLE
#137: print usage when --help is requested

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -47,12 +47,37 @@ use crate::emu::{Emu, Opt};
 /// ```
 pub fn parse_args(args: &[String]) -> Result<String, String> {
     if args.len() < 2 {
-        return Err(format!(
-            "Usage: {} <file.phie>",
-            args.first().map(|s| s.as_str()).unwrap_or("phie")
-        ));
+        return Err(usage(args));
     }
     Ok(args[1].clone())
+}
+
+/// Builds the usage line, naming the binary the way it was invoked.
+///
+/// # Arguments
+///
+/// * `args` - Command line arguments including program name
+///
+/// # Examples
+///
+/// ```
+/// use phie::cli::usage;
+///
+/// let args = vec!["phie".to_string()];
+/// assert_eq!(usage(&args), "Usage: phie <file.phie>");
+/// ```
+pub fn usage(args: &[String]) -> String {
+    format!(
+        "Usage: {} <file.phie>",
+        args.first().map(|s| s.as_str()).unwrap_or("phie")
+    )
+}
+
+/// Tells whether the arguments ask for the usage line instead of a program.
+fn help_requested(args: &[String]) -> bool {
+    args.iter()
+        .skip(1)
+        .any(|arg| arg == "--help" || arg == "-h")
 }
 
 /// Reads and returns content from a phie program file.
@@ -139,6 +164,9 @@ pub fn execute_phie(content: &str) -> Result<Data, String> {
 /// }
 /// ```
 pub fn run(args: &[String]) -> Result<String, String> {
+    if help_requested(args) {
+        return Ok(usage(args));
+    }
     let file_path = parse_args(args)?;
     let content = read_phie_file(&file_path)?;
     let result = execute_phie(&content)?;

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -254,3 +254,19 @@ fn parallel_mktemp_users_do_not_clash() {
         *collected
     );
 }
+
+#[test]
+fn prints_usage_when_help_is_requested() {
+    let args = vec!["phie".to_string(), "--help".to_string()];
+    let result = cli::run(&args);
+    assert!(result.is_ok(), "{}", result.unwrap_err());
+    assert!(result.unwrap().contains("Usage: phie <file.phie>"));
+}
+
+#[test]
+fn prints_usage_when_help_is_requested_briefly() {
+    let args = vec!["phie".to_string(), "-h".to_string()];
+    let result = cli::run(&args);
+    assert!(result.is_ok(), "{}", result.unwrap_err());
+    assert!(result.unwrap().contains("Usage: phie <file.phie>"));
+}


### PR DESCRIPTION
Closes #137

The first command the README suggests to a newcomer, `target/release/phie
--help`, exited with code 1 and printed `File '--help' does not exist`, because
`parse_args` took `args[1]` as a file name whatever it was.

Two tests were written first and both failed on `master`:
`prints_usage_when_help_is_requested` and its `-h` twin in `tests/cli_test.rs`.
Then `run` learned to recognise `--help` and `-h` and to answer with the usage
line, and the usage line itself moved into a small `usage` function so that the
no-arguments error and the help output cannot drift apart.

Behaviour now:

| Command | Output | Exit code |
|---|---|---|
| `phie --help` | `Usage: phie <file.phie>` | 0 |
| `phie -h` | `Usage: phie <file.phie>` | 0 |
| `phie` | `Usage: phie <file.phie>` on stderr | 1, as before |
| `phie program.phie` | the dataized result | 0, as before |

Verified locally: 243 tests pass including the two new ones, `cargo fmt --check`
is clean, `cargo clippy --all-targets` is clean, `target/debug/fibonacci 7 10`
still prints 21 and 210, `reuse lint` and `typos` are clean, and the built binary
was run by hand for all four cases in the table above.
