### PR TITLE
#139: teach typos the CPY transition name

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -4,3 +4,5 @@
 [default.extend-words]
 # Don't correct the Transition "FND"
 FND = "FND"
+# Don't correct the Transition "CPY"
+CPY = "CPY"


### PR DESCRIPTION
Closes #139

`_typos.toml` already exempts `FND`; this adds `CPY` beside it, in the same shape and with the same kind of comment. Two lines.

The dictionary in `typos` 1.48.0 reports `CPY` as a misspelling of `COPY` or `CPU`, six times across `src/perf.rs`, `src/emu/transitions.rs` and `src/emu/tests.rs`. Every one of them is the deliberate three-letter transition code, just like `FND`, `PPG`, `DLG` and `DEL`.

This is what currently keeps #132 red: that pull request upgrades the action from 1.38.1 to 1.48.0, every other check on it passes, and `typos` fails for this reason alone. With this merged, that upgrade goes green.

Verified by running `typos` 1.48.0 over the whole repository on this branch: no findings.